### PR TITLE
Remove pixelRatio

### DIFF
--- a/lib/generate-new-cropped-image-file.ts
+++ b/lib/generate-new-cropped-image-file.ts
@@ -17,17 +17,10 @@ export async function generateNewCroppedImageFile(
 
   const scaleX = image.naturalWidth / image.width;
   const scaleY = image.naturalHeight / image.height;
-  // devicePixelRatio slightly increases sharpness on retina devices
-  // at the expense of slightly slower render times and needing to
-  // size the image back down if you want to download/upload and be
-  // true to the images natural size.
-  const pixelRatio = window.devicePixelRatio;
-  // const pixelRatio = 1
 
-  canvas.width = Math.floor(crop.width * scaleX * pixelRatio);
-  canvas.height = Math.floor(crop.height * scaleY * pixelRatio);
+  canvas.width = Math.floor(crop.width * scaleX);
+  canvas.height = Math.floor(crop.height * scaleY);
 
-  ctx.scale(pixelRatio, pixelRatio);
   ctx.imageSmoothingQuality = "high";
 
   const cropX = crop.x * scaleX;


### PR DESCRIPTION
This gets closer to fixing #23, but doesn't prevent large images. So if you upload a really large image, especially on iOS, it will still silently fail.