### PR TITLE
save a step attempt

### DIFF
--- a/components/passport/index.tsx
+++ b/components/passport/index.tsx
@@ -23,14 +23,17 @@ export function Passport({
         fontFamily: '"Inter"',
         color: "black",
         backgroundImage: `url('${dataPageBgUrl}')`,
-        backgroundSize: "100% 100%",
-        width: "100%",
-        height: "100%",
+        backgroundSize: `100% 100%`,
+        width: 475.86 * IMAGE_GENERATION_SCALE_FACTOR,
+        height: 324.63 * IMAGE_GENERATION_SCALE_FACTOR,
         padding: `${16 * IMAGE_GENERATION_SCALE_FACTOR}px ${
           24 * IMAGE_GENERATION_SCALE_FACTOR
         }px`,
         display: "flex",
         flexDirection: "column",
+
+        transform: "rotate(90deg) translateY(-100%)",
+        transformOrigin: "top left",
       }}
     >
       <div

--- a/components/playground.tsx
+++ b/components/playground.tsx
@@ -158,7 +158,7 @@ export default function Playground({
     }
 
     // todo: use promise.all
-    const postRes: ImageResponse = await fetch(`/api/generate-data-page`, {
+    const postRes: ImageResponse = await fetch(`/api/generate-full-frame`, {
       method: "POST",
       body: apiFormData,
     });

--- a/lib/generate-data-page.tsx
+++ b/lib/generate-data-page.tsx
@@ -101,13 +101,18 @@ export async function generateDataPage(
 }
 
 export async function generateFullFrame(data: ExpectedData, url?: string) {
-  const { interFontData, interBoldFontData, OCRBProFontData } =
-    await fetchAssets(data, url);
+  const {
+    interFontData,
+    interBoldFontData,
+    OCRBProFontData,
+    dataPageBgUrl,
+    portraitUrlB64,
+  } = await fetchAssets(data, url);
 
-  const dataPage = Buffer.from(
-    await (await generateDataPage(data, url)).arrayBuffer()
-  );
-  const dataPageUrlB64 = "data:image/png;base64," + dataPage.toString("base64");
+  // const dataPage = Buffer.from(
+  //   await (await generateDataPage(data, url)).arrayBuffer()
+  // );
+  // const dataPageUrlB64 = "data:image/png;base64," + dataPage.toString("base64");
 
   const secondHalfUrl = `${process.env.R2_PUBLIC_URL}/page-1-second-half.png`;
 
@@ -129,14 +134,10 @@ export async function generateFullFrame(data: ExpectedData, url?: string) {
             height: 475.86 * IMAGE_GENERATION_SCALE_FACTOR,
           }}
         >
-          <img
-            src={dataPageUrlB64}
-            width={475.86 * IMAGE_GENERATION_SCALE_FACTOR}
-            height={324.63 * IMAGE_GENERATION_SCALE_FACTOR}
-            style={{
-              transform: "rotate(90deg) translateY(-100%)",
-              transformOrigin: "top left",
-            }}
+          <Passport
+            data={data}
+            dataPageBgUrl={dataPageBgUrl}
+            portraitUrlB64={portraitUrlB64}
           />
         </div>
         <img


### PR DESCRIPTION
Closing this without merging. Hopefully someone can figure it out.

The approach I'm taking to solve #25 currently involves calling satori to generate the data page, then positioning the rotated image on the 8.5x11-shaped frame. This gives the desired effect, but it's an inefficient way to go about it when you could just generate the image from satori rotated, thus saving a call to satori.

The problem: while the passport design in Figma is 472 x 332, the actual dimensions on the 8.5x11 frame are 475.86 x 324.63. The approach I merged works because I generate the image as 472x332 and then slightly squish it, which is effectively what I do when I make the prototypes in Figma. But I can't figure out the correct dimensions such that the image looks correct when I try to generate it directly via Satori.

I'm shipping without this optimization, but making this PR to have a record for myself or anyone else in the future who wants to take another crack at it.